### PR TITLE
Lower Cabal-version: to >= 1.10

### DIFF
--- a/crackNum.cabal
+++ b/crackNum.cabal
@@ -11,7 +11,7 @@ Maintainer:          erkokl@gmail.com
 Copyright:           Levent Erkok
 Category:            Tools
 Build-type:          Simple
-Cabal-version:       >= 1.14
+Cabal-version:       >= 1.10
 Extra-Source-Files:  INSTALL, README.md, COPYRIGHT, CHANGES.md
 
 source-repository head


### PR DESCRIPTION
There is no new features in 1.12 or 1.13, so the bound can be lowered.

Note: no new release are required. I made revisions on Hackage, so the whole matrix is green: https://hackage.haskell.org/package/crackNum
